### PR TITLE
add sliver cross axis constrained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
+## [0.1.3] - 2020-09-11
+
+Added [SliverCrossAxisConstrained] with thanks to @remonh87
+
 ## [0.1.2+3] - 2020-09-07
 
 - Improved handling of reverse scroll direction
-- Added `insetOnOverlap` parameter to `SliverStack`
+- Added `insetOnOverlap` parameter to [SliverStack]
 
 ## [0.1.2+2] - 2020-09-07
 
@@ -10,9 +14,9 @@ Fixed a small analysis issue
 ## [0.1.2] - 2020-09-07
 
 Added the following widgets:
-- [SliverStack](https://github.com/Kavantix/sliver_tools/blob/master/lib/src/sliver_stack.dart)
-- [SliverClip](https://github.com/Kavantix/sliver_tools/blob/master/lib/src/sliver_clip.dart)
-- [SliverAnimatedSwitcher](https://github.com/Kavantix/sliver_tools/blob/master/lib/src/sliver_animated_switcher.dart)
+- [SliverStack]
+- [SliverClip]
+- [SliverAnimatedSwitcher]
 
 ## [0.1.1] - 2020-09-03
 
@@ -21,5 +25,12 @@ Updated readme and changelog links
 ## [0.1.0] - 2020-09-03
 
 Initial release including:
-- [MultiSliver](https://github.com/Kavantix/sliver_tools/blob/master/lib/src/multi_sliver.dart)
-- [SliverAnimatedPaintExtent](https://github.com/Kavantix/sliver_tools/blob/master/lib/src/sliver_animated_paint_extent.dart)
+- [MultiSliver]
+- [SliverAnimatedPaintExtent]
+
+[MultiSliver]: https://github.com/Kavantix/sliver_tools/blob/master/lib/src/multi_sliver.dart
+[SliverAnimatedPaintExtent]: https://github.com/Kavantix/sliver_tools/blob/master/lib/src/sliver_animated_paint_extent.dart
+[SliverStack]: https://github.com/Kavantix/sliver_tools/blob/master/lib/src/sliver_stack.dart
+[SliverClip]: https://github.com/Kavantix/sliver_tools/blob/master/lib/src/sliver_clip.dart
+[SliverAnimatedSwitcher]: https://github.com/Kavantix/sliver_tools/blob/master/lib/src/sliver_animated_switcher.dart
+[SliverCrossAxisConstrained]: https://github.com/Kavantix/sliver_tools/blob/master/lib/src/sliver_cross_axis_constrained.dart

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ class NewsPage extends StatelessWidget {
 }
 ```
 
-## [MultiSliver](https://github.com/Kavantix/sliver_tools/blob/master/lib/src/multi_sliver.dart)
+## [MultiSliver]
 
-The `MultiSliver` widget allows for grouping of multiple slivers together such that they can be returned as a single widget.
+The [MultiSliver] widget allows for grouping of multiple slivers together such that they can be returned as a single widget.
 For instance when one wants to wrap a few slivers with some padding or an inherited widget.
 
 
@@ -69,7 +69,7 @@ The `pushPinnedChildren` parameter allows for achieving a 'sticky header' effect
 
 ## [SliverStack](https://github.com/Kavantix/sliver_tools/blob/master/lib/src/sliver_stack.dart)
 
-The `SliverStack` widget allows for stacking of both slivers and box widgets.
+The [SliverStack] widget allows for stacking of both slivers and box widgets.
 This can be useful for adding some decoration to a sliver.
 Which is what some of the other widgets in this package use to get their desired effects.
 
@@ -105,9 +105,9 @@ class WidgetThatReturnsASliver extends StatelessWidget {
 
 The `insetOnOverlap` handles whether the positioned children should be inset (made smaller) when the sliver has overlap from a previous sliver.
 
-## [SliverClip](https://github.com/Kavantix/sliver_tools/blob/master/lib/src/sliver_clip.dart)
+## [SliverClip]
 
-The `SliverClip` widget will add a clip around its child from the child's paintOrigin to its paintExtent.
+The [SliverClip] widget will add a clip around its child from the child's paintOrigin to its paintExtent.
 This is very useful and most likely what you want when using a pinned SliverPersistentHeader as child of the stack.
 
 ### Example
@@ -127,9 +127,9 @@ The `clipOverlap` parameter allows for configuring whether any overlap with the 
 This can be useful when one has a SliverPersitentHeader above a SliverList and does not want to give the header an opaque background but also prevent the list from drawing underneath the header.
 
 
-## [SliverAnimatedPaintExtent](https://github.com/Kavantix/sliver_tools/blob/master/lib/src/sliver_animated_paint_extent.dart)
+## [SliverAnimatedPaintExtent]
 
-The `SliverAnimatedPaintExtent` widget allows for having a smooth transition when a sliver changes the space it will occupy inside the viewport.
+The [SliverAnimatedPaintExtent] widget allows for having a smooth transition when a sliver changes the space it will occupy inside the viewport.
 For instance when using a SliverList with a button below it that loads the next few items.
 
 
@@ -146,7 +146,37 @@ class WidgetThatReturnsASliver extends StatelessWidget {
 }
 ```
 
-## [SliverAnimatedSwitcher](https://github.com/Kavantix/sliver_tools/blob/master/lib/src/sliver_animated_switcher.dart)
+## [SliverAnimatedSwitcher]
 
-The `SliverAnimatedSwitcher` widget is simply a pre-configured `AnimatedSwitcher` widget.
-If one needs more options than supplied by this widget a regular `AnimatedSwitcher` can be used by giving it the `defaultLayoutBuilder` and `defaultTransitionBuilder` of `SliverAnimatedSwitcher`.
+The [SliverAnimatedSwitcher] widget is simply a pre-configured `AnimatedSwitcher` widget.
+If one needs more options than supplied by this widget a regular `AnimatedSwitcher` can be used by giving it the `defaultLayoutBuilder` and `defaultTransitionBuilder` of [SliverAnimatedSwitcher].
+
+
+## [SliverCrossAxisConstrained]
+
+The [SliverCrossAxisConstrained] widget allows for limiting the cross axis extent of a sliver to a maximum value given by the `maxCrossAxisExtent`.
+For instance a long list of text items on an iPad would be too wide to read so one can wrap the SliverList in a [SliverCrossAxisConstrained] and limit its width to something more reasonable.
+
+
+### Example
+```dart
+class WidgetThatReturnsASliver extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return SliverCrossAxisConstrained(
+      maxCrossAxisExtent: 700,
+      child: SliverList(...),
+    );
+  }
+}
+```
+
+
+
+
+[MultiSliver]: https://github.com/Kavantix/sliver_tools/blob/master/lib/src/multi_sliver.dart
+[SliverAnimatedPaintExtent]: https://github.com/Kavantix/sliver_tools/blob/master/lib/src/sliver_animated_paint_extent.dart
+[SliverStack]: https://github.com/Kavantix/sliver_tools/blob/master/lib/src/sliver_stack.dart
+[SliverClip]: https://github.com/Kavantix/sliver_tools/blob/master/lib/src/sliver_clip.dart
+[SliverAnimatedSwitcher]: https://github.com/Kavantix/sliver_tools/blob/master/lib/src/sliver_animated_switcher.dart
+[SliverCrossAxisConstrained]: https://github.com/Kavantix/sliver_tools/blob/master/lib/src/sliver_cross_axis_constrained.dart

--- a/lib/sliver_tools.dart
+++ b/lib/sliver_tools.dart
@@ -1,5 +1,6 @@
 export 'src/multi_sliver.dart';
 export 'src/sliver_animated_paint_extent.dart';
-export 'src/sliver_clip.dart';
-export 'src/sliver_stack.dart';
 export 'src/sliver_animated_switcher.dart';
+export 'src/sliver_clip.dart';
+export 'src/sliver_cross_axis_constrained.dart';
+export 'src/sliver_stack.dart';

--- a/lib/src/sliver_cross_axis_constrained.dart
+++ b/lib/src/sliver_cross_axis_constrained.dart
@@ -1,0 +1,176 @@
+import 'dart:math';
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+/// Constraints and centers the child [sliver] to a maximum cross axis extent
+///  specified by [maxCrossAxisExtent].
+class SliverCrossAxisConstrained extends SingleChildRenderObjectWidget {
+  const SliverCrossAxisConstrained({
+    @required this.maxCrossAxisExtent,
+    Key key,
+    Widget sliver,
+  })  : assert(maxCrossAxisExtent != null),
+        super(key: key, child: sliver);
+
+  /// Max allowed limit of the cross axis
+  final double maxCrossAxisExtent;
+
+  @override
+  RenderSliverCrossAxisConstrained createRenderObject(BuildContext context) =>
+      RenderSliverCrossAxisConstrained(maxCrossAxisExtent: maxCrossAxisExtent);
+
+  @override
+  void updateRenderObject(
+      BuildContext context, RenderSliverCrossAxisConstrained renderObject) {
+    renderObject.maxCrossAxisExtent = maxCrossAxisExtent;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(
+        DiagnosticsProperty<double>('maxCrossAxisExtent', maxCrossAxisExtent));
+  }
+}
+
+class RenderSliverCrossAxisConstrained extends RenderSliver
+    with RenderObjectWithChildMixin<RenderSliver> {
+  double _maxCrossAxisExtent;
+
+  RenderSliverCrossAxisConstrained(
+      {double maxCrossAxisExtent, RenderSliver child})
+      : _maxCrossAxisExtent = maxCrossAxisExtent {
+    this.child = child;
+  }
+
+  set maxCrossAxisExtent(double value) {
+    assert(value != null);
+    assert(value > 0);
+    if (_maxCrossAxisExtent == value) return;
+    _maxCrossAxisExtent = value;
+    markNeedsLayout();
+  }
+
+  double get maxCrossAxisExtent => _maxCrossAxisExtent;
+
+  @override
+  void setupParentData(RenderObject child) {
+    if (child.parentData is! SliverPhysicalParentData)
+      child.parentData = SliverPhysicalParentData();
+  }
+
+  @override
+  void performLayout() {
+    child.layout(
+        constraints.copyWith(
+            crossAxisExtent:
+                min(constraints.crossAxisExtent, _maxCrossAxisExtent)),
+        parentUsesSize: true);
+
+    final childLayoutGeometry = child.geometry;
+    if (childLayoutGeometry.scrollOffsetCorrection != null) {
+      geometry = SliverGeometry(
+        scrollOffsetCorrection: childLayoutGeometry.scrollOffsetCorrection,
+      );
+      return;
+    }
+
+    geometry = SliverGeometry(
+      scrollExtent: childLayoutGeometry.scrollExtent,
+      paintExtent: childLayoutGeometry.paintExtent,
+      layoutExtent: childLayoutGeometry.layoutExtent,
+      cacheExtent: childLayoutGeometry.cacheExtent,
+      maxPaintExtent: childLayoutGeometry.maxPaintExtent,
+      hitTestExtent: childLayoutGeometry.hitTestExtent,
+      hasVisualOverflow: childLayoutGeometry.hasVisualOverflow,
+    );
+
+    final childParentData = child.parentData as SliverPhysicalParentData;
+    switch (applyGrowthDirectionToAxisDirection(
+        constraints.axisDirection, constraints.growthDirection)) {
+      case AxisDirection.up:
+      case AxisDirection.down:
+        childParentData.paintOffset =
+            Offset(childCrossAxisPosition(child), 0.0);
+        break;
+      case AxisDirection.right:
+      case AxisDirection.left:
+        childParentData.paintOffset =
+            Offset(0.0, childCrossAxisPosition(child));
+        break;
+    }
+  }
+
+  @override
+  bool hitTestChildren(SliverHitTestResult result,
+      {@required double mainAxisPosition, @required double crossAxisPosition}) {
+    if (child != null && child.geometry.hitTestExtent > 0.0)
+      return child.hitTest(result,
+          mainAxisPosition: mainAxisPosition - childMainAxisPosition(child),
+          crossAxisPosition: crossAxisPosition - childCrossAxisPosition(child));
+    return false;
+  }
+
+  @override
+  double childMainAxisPosition(RenderSliver child) => 0;
+
+  @override
+  double childCrossAxisPosition(RenderSliver child) {
+    assert(child != null);
+    assert(child == this.child);
+    assert(constraints != null);
+    assert(constraints.crossAxisExtent != null);
+    assert(child.constraints.crossAxisExtent != null);
+    return (constraints.crossAxisExtent - child.constraints.crossAxisExtent) /
+        2;
+  }
+
+  @override
+  void applyPaintTransform(RenderObject child, Matrix4 transform) {
+    assert(child != null);
+    assert(child == this.child);
+    final childParentData = child.parentData as SliverPhysicalParentData;
+    childParentData
+        .applyPaintTransform(transform); // ignore: cascade_invocations
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    if (child != null && child.geometry.visible) {
+      final childParentData = child.parentData as SliverPhysicalParentData;
+      context.paintChild(child, offset + childParentData.paintOffset);
+    }
+  }
+
+  @override
+  void debugPaint(PaintingContext context, Offset offset) {
+    super.debugPaint(context, offset);
+    assert(() {
+      if (debugPaintSizeEnabled) {
+        final parentSize = getAbsoluteSizeRelativeToOrigin();
+        final outerRect = offset & parentSize;
+        Size childSize;
+        Rect innerRect;
+        if (child != null) {
+          childSize = child.getAbsoluteSizeRelativeToOrigin();
+          final childParentData = child.parentData as SliverPhysicalParentData;
+          innerRect = (offset + childParentData.paintOffset) & childSize;
+          assert(innerRect.top >= outerRect.top);
+          assert(innerRect.left >= outerRect.left);
+          assert(innerRect.right <= outerRect.right);
+          assert(innerRect.bottom <= outerRect.bottom);
+        }
+        debugPaintPadding(context.canvas, outerRect, innerRect);
+      }
+      return true;
+    }());
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(
+        DiagnosticsProperty<double>('maxCrossAxisExtent', maxCrossAxisExtent));
+  }
+}

--- a/lib/src/sliver_cross_axis_constrained.dart
+++ b/lib/src/sliver_cross_axis_constrained.dart
@@ -3,15 +3,15 @@ import 'dart:math';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
-/// Constraints and centers the child [sliver] to a maximum cross axis extent
+/// Constraints and centers the [child] sliver to a maximum cross axis extent
 ///  specified by [maxCrossAxisExtent].
 class SliverCrossAxisConstrained extends SingleChildRenderObjectWidget {
   const SliverCrossAxisConstrained({
     @required this.maxCrossAxisExtent,
     Key key,
-    Widget sliver,
+    Widget child,
   })  : assert(maxCrossAxisExtent != null),
-        super(key: key, child: sliver);
+        super(key: key, child: child);
 
   /// Max allowed limit of the cross axis
   final double maxCrossAxisExtent;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sliver_tools
 description: A set of useful sliver tools that are missing from the flutter framework
-version: 0.1.2+3
+version: 0.1.3
 homepage: https://github.com/Kavantix
 repository: https://github.com/Kavantix/sliver_tools
 issue_tracker: https://github.com/Kavantix/sliver_tools/issues

--- a/test/sliver_cross_axis_constrained_test.dart
+++ b/test/sliver_cross_axis_constrained_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../lib/src/sliver_cross_axis_constrained.dart';
+
+void main() {
+  Widget _createSut(Widget sliver, double maxCrossAxisExtend) {
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: CustomScrollView(
+        slivers: [
+          SliverCrossAxisConstrained(
+            maxCrossAxisExtent: maxCrossAxisExtend,
+            sliver: sliver,
+          ),
+        ],
+      ),
+    );
+  }
+
+  group('SliverCrossAxisConstrained', () {
+    double maxCrossAxisExtent;
+    Widget sut;
+    Size windowSize;
+    setUp(() {
+      maxCrossAxisExtent = 300;
+      sut = _createSut(
+        const SliverToBoxAdapter(
+          child: SizedBox(
+            width: double.infinity,
+            height: 100,
+          ),
+        ),
+        maxCrossAxisExtent,
+      );
+    });
+
+    group('Given window size is smaller then max extent', () {
+      setUp(() {
+        windowSize = const Size(200, 400);
+      });
+      testWidgets('It sizes sliver to available space', (tester) async {
+        tester.binding.window.physicalSizeTestValue = windowSize;
+        await tester.pumpWidget(sut);
+        await tester.pumpAndSettle();
+
+        final width = await tester
+            .renderObject(find.byType(SliverToBoxAdapter))
+            .paintBounds
+            .width;
+
+        expect(width < maxCrossAxisExtent, true);
+      });
+    });
+
+    group('Given window size is bigger then max extent', () {
+      setUp(() {
+        windowSize = const Size(1200, 400);
+      });
+
+      testWidgets('It sizes sliver tto max extent', (tester) async {
+        tester.binding.window.physicalSizeTestValue = windowSize;
+        await tester.pumpWidget(sut);
+        await tester.pumpAndSettle();
+
+        final renderObject =
+            await tester.renderObject(find.byType(SliverToBoxAdapter));
+
+        expect(renderObject.paintBounds.width, maxCrossAxisExtent);
+      });
+    });
+  });
+}

--- a/test/sliver_cross_axis_constrained_test.dart
+++ b/test/sliver_cross_axis_constrained_test.dart
@@ -11,7 +11,7 @@ void main() {
         slivers: [
           SliverCrossAxisConstrained(
             maxCrossAxisExtent: maxCrossAxisExtend,
-            sliver: sliver,
+            child: sliver,
           ),
         ],
       ),


### PR DESCRIPTION
Added basic SliverCrossAxisConstrained widget that limits the cross axis and centers the child sliver. Quite useful for tablets

Fixes #1