### PR TITLE
Fixed issue where clipRect is null

### DIFF
--- a/lib/src/rendering/sliver_clip.dart
+++ b/lib/src/rendering/sliver_clip.dart
@@ -69,6 +69,7 @@ class RenderSliverClip extends RenderProxySliver {
       {required double mainAxisPosition, required double crossAxisPosition}) {
     final double overlapCorrection = (clipOverlap ? constraints.overlap : 0);
     return child != null &&
+        clipRect != null &&
         child!.geometry!.hitTestExtent > 0 &&
         mainAxisPosition > (geometry!.paintOrigin + overlapCorrection) &&
         mainAxisPosition <


### PR DESCRIPTION
Sometimes (only on the web build) I see a situation where the `hitTestChildren` function is called before the `paint`, which causes a nullpointer error on `clipRect` variable. In this pull request, I added a check for this situation.