### PR TITLE
Add missing parameters to SliverAnimatedSwitcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.11
+
+Added `reverseDuration`, `switchInCurve` and `switchOutCurve` to [SliverAnimatedSwitcher]
+
 # 0.2.10
 
 Fixed issue with hit testing of [SliverCrossAxisConstrained].

--- a/lib/src/sliver_animated_switcher.dart
+++ b/lib/src/sliver_animated_switcher.dart
@@ -15,10 +15,22 @@ class SliverAnimatedSwitcher extends StatelessWidget {
   /// The duration to pass to the [AnimatedSwitcher]
   final Duration duration;
 
+  /// The reverse duration to pass to the [AnimatedSwitcher]
+  final Duration? reverseDuration;
+
+  /// The switch in curve to pass to the [AnimatedSwitcher]
+  final Curve switchInCurve;
+
+  /// The switch out curve to pass to the [AnimatedSwitcher]
+  final Curve switchOutCurve;
+
   const SliverAnimatedSwitcher({
     Key? key,
     required this.child,
     required this.duration,
+    this.reverseDuration,
+    this.switchInCurve = Curves.linear,
+    this.switchOutCurve = Curves.linear,
   }) : super(key: key);
 
   static Widget defaultLayoutBuilder(
@@ -39,6 +51,9 @@ class SliverAnimatedSwitcher extends StatelessWidget {
   Widget build(BuildContext context) {
     return AnimatedSwitcher(
       duration: duration,
+      reverseDuration: reverseDuration,
+      switchInCurve: switchInCurve,
+      switchOutCurve: switchOutCurve,
       layoutBuilder: defaultLayoutBuilder,
       transitionBuilder: defaultTransitionBuilder,
       child: child,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sliver_tools
 description: A set of useful sliver tools that are missing from the flutter framework
-version: 0.2.10
+version: 0.2.11
 homepage: https://github.com/Kavantix
 repository: https://github.com/Kavantix/sliver_tools
 issue_tracker: https://github.com/Kavantix/sliver_tools/issues


### PR DESCRIPTION
There are some parameters that are present in `AnimatedSwitcher` but not `SliverAnimatedSwitcher`. This pull request adds those missing parameters.