### PR TITLE
Replace AbstractNode with RenderObject.

### DIFF
--- a/lib/src/sliver_stack.dart
+++ b/lib/src/sliver_stack.dart
@@ -279,7 +279,7 @@ class SliverPositioned extends ParentDataWidget<SliverStackParentData> {
     }
 
     if (needsLayout) {
-      final AbstractNode? targetParent = renderObject.parent;
+      final RenderObject? targetParent = renderObject.parent;
       if (targetParent is RenderObject) targetParent.markNeedsLayout();
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sliver_tools
 description: A set of useful sliver tools that are missing from the flutter framework
-version: 0.2.10
+version: 0.3.0
 homepage: https://github.com/Kavantix
 repository: https://github.com/Kavantix/sliver_tools
 issue_tracker: https://github.com/Kavantix/sliver_tools/issues


### PR DESCRIPTION
Closes #78.

Bump minor version as this would be a breaking change for users of older Flutter SDKs.